### PR TITLE
modified jquery.formvalidation.js to refresh language var after jQueryFormUtils.LANG extended with customized localization strings

### DIFF
--- a/jquery.formvalidator.js
+++ b/jquery.formvalidator.js
@@ -95,9 +95,9 @@
             }
             if (language) {
                 $.extend(jQueryFormUtils.LANG,language);
-            } else {
-                language = jQueryFormUtils.LANG;
             }
+            // get updated dialog strings
+            language = jQueryFormUtils.LANG;
 
             var elementType = $element.attr('type');
             if (jQueryFormUtils.defaultBorderColor === null && elementType !== 'submit' && elementType !== 'checkbox' && elementType !== 'radio') {
@@ -168,11 +168,10 @@
             }
             if (language) {
                 $.extend(jQueryFormUtils.LANG, language);
-            } else {
-                language = jQueryFormUtils.LANG;
-            }
+            } 
+	    // get updated dialog strings
+            language = jQueryFormUtils.LANG;
 
-            
             /**
              * Tells whether or not to validate element with this name and of this type
              *


### PR DESCRIPTION
minimized version needs updating after you approve this pull

I discovered an issue when trying to use localization (changing the error dialogs to show customized strings).

when creating an var object to hold customized strings for the error dialogs, and only setting values for a 1 or 2 of those strings, i.e. errorTitle, requiredFields, etc., the other default values were showing as "undefined".

tracing through the code, it appeared the object being passed to the validate and doValidate functions was not the updated jQueryFormUtils.LANG object, but the var object that contained the customized strings.

so I modified the code that extended the jQueryFormUtils.LANG object, to refresh the language var with the updated jQueryFormUtils.LANG object.

I did that in two places, in the validate and doValidation functions, as you'll see if my branch.
