### PR TITLE
Multi-Class support for error messages

### DIFF
--- a/jquery.formvalidator.js
+++ b/jquery.formvalidator.js
@@ -270,7 +270,7 @@
             //
             // Remove possible error messages from last validation
             //
-            $('.' + config.errorMessageClass).remove();
+            $('.' + config.errorMessageClass.split(' ').join('.')).remove();
             $('.jquery_form_error_message').remove();
 
 


### PR DESCRIPTION
Currently, there is a bug when removing an error message with multiple classes, as it will search for $(".class1 class2") instead of $(".class1.class2"). This came up because the default error message class for Twitter Bootstrap is "alert alert-error".
