### PR TITLE
Fixed multiple select input "length" issue

### DIFF
--- a/jquery.formvalidator.js
+++ b/jquery.formvalidator.js
@@ -796,33 +796,8 @@ jQueryFormUtils.validateInput = function(el, language, config, form) {
         return true;
     }
 
-    // Select lists with multiple options (most likely at least)
-    if(typeof value == 'object') {
-        var createFakeInput = function(val) {
-            var fake = el.clone(false);
-            fake
-                .removeAttr('multiple')
-                .children()
-                    .remove();
-
-            $('<option value="'+val+'" selected="selected"></option>').appendTo(fake);
-            return fake;
-        };
-        if(!value) {
-            return jQueryFormUtils.validateInput(createFakeInput(''), language, config, form);
-        }
-        else {
-            var isValid;
-            for(var i=0; i < value.length; i++) {
-                isValid = jQueryFormUtils.validateInput(createFakeInput(value[i]), language, config, form);
-                if(isValid !== true)
-                    return isValid;
-            }
-            return true;
-        }
-    }
-
-    value = $.trim(value);
+    value = value || '';	// coerce to empty string if null
+    
     var validationRules = el.attr(config.validationRuleAttribute);
 
     // see if form element has inline err msg attribute


### PR DESCRIPTION
Now one can drop `size=""` specification, and rely only on `validate_length` spec. Error text needs to be tweaked, as it still points to invalid number of characters, not options... but the rest is there...
