### PR TITLE
bugfix: Uncaught TypeError: Cannot read property 'length' of undefined 

### DIFF
--- a/jquery.formvalidator.js
+++ b/jquery.formvalidator.js
@@ -86,6 +86,7 @@
             var $element = $(this);
 
             var config = {
+            	    ignore : [], // Names of inputs not to be validated, overwriting attribute notaed validation
                     validationRuleAttribute : 'data-validation',
                     validationErrorMsgAttribute : 'data-validation-error-msg', // define custom err msg inline with element
                     errorElementClass : 'error', // Class that will be put on elements which value is invalid


### PR DESCRIPTION
when using onBlur validation, the doValidate function would call the function ignoreInput(), which would try to read the length property of config.ignore, but ignore was not an object in the config array.

this bug fix adds the array "ignore : [] " to the config array in the doValidate function, line 89,...
