### PR TITLE
added feature to use checkbox to force a field to be validated

### DIFF
--- a/jquery.formvalidator.js
+++ b/jquery.formvalidator.js
@@ -792,7 +792,28 @@ jQueryFormUtils.validateInput = function(el, language, config, form) {
 
     var value = el.val();
     var optional = el.attr("data-validation-optional");
-    if ((value === null || value.length == 0) && optional === 'true') {
+    
+    // test if a checkbox forces this element to be validated
+    var validate_if_checked = 0; // set initial value false
+    // get value of this element's attribute "... if-checked"
+    var validate_if_checked_el_name = el.attr("data-validation-if-checked");
+    // get the form closest to this element
+    var thisform = el.closest("form");
+    // make sure we can proceed
+    if (validate_if_checked_el_name != null && thisform != null) {
+        // select the checkbox type element in this form
+        var validate_if_checked_el_obj = thisform.find('input[name="' + validate_if_checked_el_name + '"]');
+        // test if it's property "checked" is checked
+        if ( validate_if_checked_el_obj.prop('checked') )
+            {   // set value for validation checkpoint
+                validate_if_checked = 1; 
+            } 
+    } // end if depend_checked_el_name not null
+
+
+    // validation checkpoint  (added extra criteria depend_check)
+    // if empty AND optional AND does not depend on a checkbox being checked, it is ok, return true
+    if ((value === null || value.length == 0) && optional === 'true' && !validate_if_checked) {
         return true;
     }
 


### PR DESCRIPTION
I needed a way to use a checkbox to control if a separate field needed to be validated.

for example, if you wanted to be notified of replies to your comment, you would check a checkbox. 
if that checkbox was checked, then the email form field would need to be validated.

the email address form field has the attribute "data-validation-optional"  equal to "true"
that allows us to skip validation on that form field if it is blank.

i used the same concept and added a additional attribute to the email form field.
the attribute is named "data-validation-if-checked"
the value of that attribute is the name of the checkbox type field in the form.

the script detects if the form field has that attribute, then gets it's value, finds the form element, determines if it is checked, and sets a var value.

the var value is used in the validateInput function to determine if the element should be forced to validate, appended to optional == 'true' statement

tested in G Chrome , Firefox 13.0.1 & IE 8
