### PR TITLE
Fixed no helper message on focus change

### DIFF
--- a/jquery.formvalidator.js
+++ b/jquery.formvalidator.js
@@ -692,6 +692,7 @@ jQueryFormUtils.simpleSpamCheck = function(val, classAttr) {
  * @return {Boolean}
  */
 jQueryFormUtils.validateDomain = function(val) {
+	val = val.toLowerCase();
     val = val.replace('ftp://', '').replace('https://', '').replace('http://', '').replace('www.', '');
     var arr = new Array('.com', '.net', '.org', '.biz', '.coop', '.info', '.museum', '.name', '.pro',
                         '.edu', '.gov', '.int', '.mil', '.ac', '.ad', '.ae', '.af', '.ag', '.ai', '.al',


### PR DESCRIPTION
Updated span to use .jquery_form_help_{name} format and leave helper
spans in dom after fade out. No real need to recreate the dom element
if the user brings that field back into focus.

Also added fadeIn on existing class name matches. 
