### PR TITLE
2 Bugfixes: IE validateURL & lengthRestriction

### DIFF
--- a/jquery.formvalidator.js
+++ b/jquery.formvalidator.js
@@ -1034,7 +1034,7 @@ jQueryFormUtils.validateUrl = function(url) {
     // contributed by Scott Gonzalez: http://projects.scottsplayground.com/iri/ but added support for arrays in the url ?arg[]=sdfsdf
     var urlFilter = /^(https|http|ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|\[|\]|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i;
     if(urlFilter.test(url)) {
-        var domain = url.split(/^https|^http|^ftp/i)[1].replace('://', '');
+        var domain = url.split('://')[1];
         var domainSlashPos = domain.indexOf('/');
         if(domainSlashPos > -1)
             domain = domain.substr(0, domainSlashPos);
@@ -1060,6 +1060,8 @@ jQueryFormUtils.lengthRestriction = function(inputElement, maxLengthElement) {
     $(inputElement).bind('keydown keyup keypress focus blur',  countCharacters )
                    .bind('cut paste', function(){ setTimeout(countCharacters, 100); } )
                    ;
+    // count chars on pageload, if there are prefilled input-values
+    $(document).bind("ready",countCharacters);
     // internal function does the counting and sets display value
     function countCharacters(){
         var numChars = inputElement.val().length;
@@ -1073,4 +1075,5 @@ jQueryFormUtils.lengthRestriction = function(inputElement, maxLengthElement) {
         // set counter text
         maxLengthElement.text(maxChars - numChars);
     };
+    
 };


### PR DESCRIPTION
IE 8 has problems with splitting regex-strings. this is an easy work-around.

lenghtRestriction didn't count characters, that were filled before domready (for example serverside [textarea]here is prefilled text[/textarea])
