### PR TITLE
modify valAttr setter, to allow external scripts to set element validati...

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -166,7 +166,8 @@
         } else if( val === false || val === null ) {
             return this.removeAttr('data-validation-'+name);
         } else {
-            return this.attr('data-validation-'+name, val);
+            if(name.length > 0) name='-'+name;
+            return this.attr('data-validation'+name, val);
         }
     };
 


### PR DESCRIPTION
...ons

allows ext javascript to set validation attributes using:

$("[name='group_id[]']:eq(0)")
    .valAttr('','validate-checkbox-group')
    .valAttr('qty','1-2')
    .valAttr('error-msg','chose 1, max 2')
    ;

this is useful when dealing with a group of checkboxes generated from server-side script, and you don't need validation on all the items, just he first one. an example will be forthcoming in my next patch that adds "checkbox-group" to the validation library.

existing code base would append dash / hyphen to "data-validation" attribute, thereby rendering that attribute incorrectly, forcing need to use full jQ statement " .attr(n,v) "method.
