### PR TITLE
Have build tool reference node from env

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 var fs = require('fs'),
     sys = require('sys'),


### PR DESCRIPTION
This just adds proper support for building regardless of where node resides
