### PR TITLE
Pass formQuery to jQuery instead of spliting it

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -524,9 +524,9 @@
         conf = $.extend(defaultConf, conf || {});
 
         // Add validation to forms
-        $.split(conf.form, function(formQuery) {
+        $(conf.form).each(function(i, form) {
 
-            var $form  = $(formQuery);
+            var $form  = $(form);
             $window.trigger('formValidationSetup', [$form]);
 
             // Remove all event listeners previously added


### PR DESCRIPTION
I needed this change as I'm initializing the nodes dynamically and I really do not want to give them each a unique ID. I was a bit astonished that one cannot simply pass DOM nodes directly as argument for "form".

I found that the culprit was the explicit split on the passed variable, which IMO does not make sense, since using it via jQuery.each should result in the exact same behaviour as before (IMHO).

Best regards
Marcel Greter
