### PR TITLE
This call adds an error block that gets removed in the next line

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -26,7 +26,7 @@
         },
         _removeErrorStyle = function($elem, conf) {
             $elem.each(function() {
-                _setInlineErrorMessage($(this), '', conf, conf.errorMessagePosition);
+                //_setInlineErrorMessage($(this), '', conf, conf.errorMessagePosition);
                 $(this)
                     .removeClass('valid')
                     .removeClass(conf.errorElementClass)


### PR DESCRIPTION
I got an empty error div rendered even with a valid value: <div class="form-error"></div>
When I comment this line out I get the expected behavior: something with an error, nothing when valid

    var validationmessages = $('#pcerror');
    $.validate({
        validateOnBlur: true, // enable validation when input looses focus
        errorMessagePosition: validationmessages,
        addValidClassOnAll: true
    });