### PR TITLE
Add a fix for input-group of tw-bs

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -13,12 +13,14 @@
 
     var $window = $(window),
         _applyErrorStyle = function($elem, conf) {
+            var $parent = $elem.parent();
             $elem
                 .addClass(conf.errorElementClass)
-                .removeClass('valid')
-                .parent()
-                    .addClass('has-error')
-                    .removeClass('has-success'); // twitter bs
+                .removeClass('valid');
+            if($parent.hasClass("input-group")) $parent = $parent.parent();
+            
+            $parent.addClass('has-error') .removeClass('has-success'); //twitter bs
+                
 
             if(conf.borderColorOnError !== '') {
                 $elem.css('border-color', conf.borderColorOnError);
@@ -27,19 +29,24 @@
         _removeErrorStyle = function($elem, conf) {
             $elem.each(function() {
                 _setInlineErrorMessage($(this), '', conf, conf.errorMessagePosition);
+                var $parent = $(this).parent();
+                
+                if($parent.hasClass("input-group")) $parent = $parent.parent();
                 $(this)
                     .removeClass('valid')
                     .removeClass(conf.errorElementClass)
-                    .css('border-color', '')
-                    .parent()
-                        .removeClass('has-error')
-                        .removeClass('has-success')
-                        .find('.'+conf.errorMessageClass) // remove inline error message
-                            .remove();
+                    .css('border-color', '');
+                $parent
+                    .removeClass('has-error')
+                    .removeClass('has-success')
+                    .find('.'+conf.errorMessageClass) // remove inline error message
+                        .remove();
             });
         },
         _setInlineErrorMessage = function($input, mess, conf, $messageContainer) {
             var custom = _getInlineErrorElement($input);
+            var $parent = $input.parent();
+            if($parent.hasClass("input-group")) $parent = $parent.parent();
             if( custom ) {
                 custom.innerHTML = mess;
             }
@@ -64,10 +71,10 @@
                 }
             }
             else {
-                var $mess = $input.parent().find('.'+conf.errorMessageClass+'.help-block');
+                var $mess = $parent.find('.'+conf.errorMessageClass+'.help-block');
                 if( $mess.length == 0 ) {
                     $mess = $('<span></span>').addClass('help-block').addClass(conf.errorMessageClass);
-                    $mess.appendTo($input.parent());
+                    $mess.appendTo($parent);
                 }
                 $mess.html(mess);
             }


### PR DESCRIPTION
When you have a input-group in bootstrap3, the parent is matched incorrectly, beacuse bs3 now use a div for input group, and the parent should be the parent of these div. This is a little fix for that, check if parent has class "input-group", and get's the correct parent
