### PR TITLE
prevent recheck of multiple radio buttons

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -198,7 +198,7 @@
     * @return {jQuery}
     */
     $.fn.validateInputOnBlur = function(language, conf, attachKeyupEvent, eventType) {
-        console.log(eventType);
+       
         $.formUtils.eventType = eventType;
 
         if( (this.valAttr('suggestion-nr') || this.valAttr('postpone') || this.hasClass('hasDatepicker')) && !window.postponedValidation ) {
@@ -275,7 +275,7 @@
     };
 
     /**
-     * Function that validate all inputs in given element
+     * Function that validates all inputs in active form
      *
      * @param {Object} [language]
      * @param {Object} [conf]
@@ -317,6 +317,9 @@
             }
         },
 
+	/** HoldsInputs already validated, to prevent recheck of mulitple checkboxes & radios */
+	checkedInputs = [],
+	
         /** Error messages for this validation */
         errorMessages = [],
 
@@ -350,30 +353,38 @@
         $form.find('input,textarea,select').filter(':not([type="submit"],[type="button"])').each(function() {
             var $elem = $(this);
             var elementType = $elem.attr('type');
-            if (!ignoreInput($elem.attr('name'), elementType)) {
+            var elementName = $elem.attr('name');
+            if (!ignoreInput(elementName, elementType)) {
+            	
+		// do not recheck multiple elements with same name, i.e. checkboxes, radios
+		if ($.inArray(elementName, checkedInputs) < 0 ) {
+		    checkedInputs.push(elementName);
 
-                var validation = $.formUtils.validateInput(
-                                $elem,
-                                language,
-                                conf,
-                                $form,
-                                'submit'
-                            );
-
-                // Run element validation callback
-                if( typeof conf.onElementValidate == 'function' ) {
-                    conf.onElementValidate((validation === true), $elem, $form, validation);
-                }
-
-                if(validation !== true) {
-                    addErrorMessage(validation, $elem);
-                } else {
-                    $elem
-                        .valAttr('current-error', false)
-                        .addClass('valid')
-                        .parent()
-                            .addClass('has-success');
-                }
+	            var validation = $.formUtils.validateInput(
+	                            $elem,
+	                            language,
+	                            conf,
+	                            $form,
+	                            'submit'
+	                        );
+	
+	            // Run element validation callback
+	            if( typeof conf.onElementValidate == 'function' ) {
+	                conf.onElementValidate((validation === true), $elem, $form, validation);
+	            }
+	
+	            if(validation !== true) {
+	                addErrorMessage(validation, $elem);
+	            } else {
+	                $elem
+	                    .valAttr('current-error', false)
+	                    .addClass('valid')
+	                    .parent()
+	                        .addClass('has-success');
+	            }
+                
+		}
+		
             }
 
         });
@@ -859,12 +870,13 @@
                 var validator = $.formUtils.validators[rule];
 
                 if( validator && typeof validator['validatorFunction'] == 'function' ) {
+                    
                     // special change of element for checkbox_group rule
                     if ( rule == 'validate_checkbox_group' ) {
-                        // set element to first in group, so error msg is set only once
+                        // set element to first in group, so error msg attr doesn't need to be set on all elements in group
                             $elem = $("[name='"+$elem.attr('name')+"']:eq(0)");
                     }
-
+                    
                     var isValid = null;
                     if( eventContext != 'keyup' || validator.validateOnKeyUp ) {
                         isValid = validator.validatorFunction(value, $elem, conf, language, $form);


### PR DESCRIPTION
bug detected when using validation **"required"** on group of **radio** buttons with same name attribute, i.e. "payment_method"

when not valid (i.e. no radio button was checked), an error message span would be created for each radio button element.
![untitled-1](https://cloud.githubusercontent.com/assets/206041/4136846/bebfbc20-3381-11e4-91b3-679086faf53e.gif)

this patch adds a memory array named **checkedInputs[]** 
to hold the names of elements that have been checked 
during the iteration of isValid() func,
thereby preventing a recheck of elements with the same name, 
in the situation of radio buttons.

during the iteration through each form element, each element is added to this array before it is being checked.

if the element name already exists in the array, the validation of that element will not be performed.

since each form element has unique names, except for radio buttons and checkbox groups, this should not affect other input types.

**Important Notes on Multiple Checkboxes:**

when using validation on a group of checkboxes, 
set validation rule to **checkboxes_group**, and specify qty attribute, i.e. **min1**

otherwise, the keyup event will trigger the validation on the checkbox, 
without being able to read the other checkboxes in same named group,
and you will see an error message, even though the required qty of checkboxes is checked
