### PR TITLE
resolves #155 abstracting class names has-error has-success

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -13,14 +13,15 @@
 
     var $window = $(window),
         _applyErrorStyle = function($elem, conf) {
-            var $parent = $elem.parent();
             $elem
                 .addClass(conf.errorElementClass)
                 .removeClass('valid');
-            if($parent.hasClass("input-group")) $parent = $parent.parent();
+            var $parent = $elem.parent();
+                if($parent.hasClass("input-group")) $parent = $parent.parent();
             
-            $parent.addClass('has-error') .removeClass('has-success'); //twitter bs
-                
+            $parent
+            	.addClass(conf.inputParentClassOnError)
+	        .removeClass(conf.inputParentClassOnSuccess); 
 
             if(conf.borderColorOnError !== '') {
                 $elem.css('border-color', conf.borderColorOnError);
@@ -29,24 +30,24 @@
         _removeErrorStyle = function($elem, conf) {
             $elem.each(function() {
                 _setInlineErrorMessage($(this), '', conf, conf.errorMessagePosition);
-                var $parent = $(this).parent();
                 
-                if($parent.hasClass("input-group")) $parent = $parent.parent();
                 $(this)
                     .removeClass('valid')
                     .removeClass(conf.errorElementClass)
                     .css('border-color', '');
+                
+                var $parent = $(this).parent();
+                    if($parent.hasClass("input-group")) $parent = $parent.parent();
                 $parent
-                    .removeClass('has-error')
-                    .removeClass('has-success')
-                    .find('.'+conf.errorMessageClass) // remove inline error message
+                    .removeClass(conf.inputParentClassOnError)
+		    .removeClass(conf.inputParentClassOnSuccess); 
+                    .find('.'+conf.errorMessageClass) // remove inline span holding error message
                         .remove();
             });
         },
         _setInlineErrorMessage = function($input, mess, conf, $messageContainer) {
             var custom = _getInlineErrorElement($input);
-            var $parent = $input.parent();
-            if($parent.hasClass("input-group")) $parent = $parent.parent();
+            
             if( custom ) {
                 custom.innerHTML = mess;
             }
@@ -71,6 +72,8 @@
                 }
             }
             else {
+            	var $parent = $input.parent();
+	            if($parent.hasClass("input-group")) $parent = $parent.parent();
                 var $mess = $parent.find('.'+conf.errorMessageClass+'.help-block');
                 if( $mess.length == 0 ) {
                     $mess = $('<span></span>').addClass('help-block').addClass(conf.errorMessageClass);
@@ -236,7 +239,8 @@
             $elem
                 .addClass('valid')
                 .parent()
-                    .addClass('has-success'); // twitter bs
+                    .addClass(conf.inputParentClassOnSuccess); 
+                    
         } else if(validation !== null) {
 
             _applyErrorStyle($elem, conf);
@@ -372,7 +376,7 @@
                         .valAttr('current-error', false)
                         .addClass('valid')
                         .parent()
-                            .addClass('has-success');
+                            .addClass(conf.inputParentClassOnSuccess);
                 }
             }
 
@@ -621,7 +625,9 @@
                 scrollToTopOnError : true,
                 dateFormat : 'yyyy-mm-dd',
                 addValidClassOnAll : false, // whether or not to apply class="valid" even if the input wasn't validated
-                decimalSeparator : '.'
+                decimalSeparator : '.',
+                inputParentClassOnError : 'has-error', // twitter-bootstrap default class name
+                inputParentClassOnSuccess : 'has-success' // twitter-bootstrap default class name
             }
         },
 


### PR DESCRIPTION
resolves issue #155 
by removing the hard-coded class names used by twitter bootstrap
to allow developer to use other class names used by other css frameworks, i.e. Zurb Foundation

also moving some code around for better readability
