### PR TITLE
Fix applying has-success and has-error classes to the same container

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -232,10 +232,12 @@
                         );
         
         if(validation === true) {
-            $elem
+            var $parent = $elem
                 .addClass('valid')
-                .parent()
-                    .addClass('has-success'); // twitter bs
+                .parent();
+
+            if($parent.hasClass("input-group")) $parent = $parent.parent();
+            $parent.addClass('has-success'); // twitter bs
         } else if(validation !== null) {
 
             _applyErrorStyle($elem, conf);


### PR DESCRIPTION
### Previous behaviour:

```
<div class="control-group">
  <div class="controls input-group has-success">
    <span class="input-group-addon">
      <span class="fa fa-user"></span>
    </span>
    <input class="form-control valid" data-validation-error-msg="Provide your name" data-validation="required" placeholder="Your name" type="text" style="">
  </div>
</div>
```

```
<div class="control-group has-error">
  <div class="controls input-group">
    <span class="input-group-addon">
      <span class="fa fa-user"></span>
    </span>
    <input class="form-control error" data-validation-error-msg="Provide your name" data-validation="required" placeholder="Your name" type="text" style="border-color: red;">
  </div>
  <span class="help-block form-error">Provide your name</span>
</div>
```

**has-success** and **has-error** are applied to different elements.
### Fixed behaviour:

```
<div class="control-group has-success">
  <div class="controls input-group">
    <span class="input-group-addon">
      <span class="fa fa-user"></span>
    </span>
    <input class="form-control valid" data-validation-error-msg="Provide your name" data-validation="required" placeholder="Your name" type="text" style="">
  </div>
</div>
```

```
<div class="control-group has-error">
  <div class="controls input-group">
    <span class="input-group-addon">
      <span class="fa fa-user"></span>
    </span>
    <input class="form-control error" data-validation-error-msg="Provide your name" data-validation="required" placeholder="Your name" type="text" style="border-color: red;">
  </div>
  <span class="help-block form-error">Provide your name</span>
</div>
```

**has-success** and **has-error** are applied to the same element.
