### PR TITLE
findScriptPathAndLoadModules speed up path

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -762,16 +762,11 @@
             } else {
                 var findScriptPathAndLoadModules = function() {
                     var foundPath = false;
-                    $('script').each(function() {
-                        if( this.src ) {
-                            var scriptName = this.src.substr(this.src.lastIndexOf('/')+1, this.src.length);
-                            if(scriptName.indexOf('jquery.form-validator.js') > -1 || scriptName.indexOf('jquery.form-validator.min.js') > -1) {
-                                foundPath = this.src.substr(0, this.src.lastIndexOf('/')) + '/';
-                                if( foundPath == '/' )
-                                    foundPath = '';
-                                return false;
-                            }
-                        }
+                    $('script[src*="form-validator"]').each(function() {
+                        foundPath = this.src.substr(0, this.src.lastIndexOf('/')) + '/';
+                        if( foundPath == '/' )
+                            foundPath = '';
+                        return false;
                     });
 
                     if( foundPath !== false) {


### PR DESCRIPTION
speed up path detection 
instead of looping through each script in DOM and checking src to see if it is form-validator,
change jQ selector to use AttributeContains modifier
so the correct script is detected the first loop
