### PR TITLE
server validation, stop removal of attr holding err msg

### DIFF
--- a/form-validator/security.dev.js
+++ b/form-validator/security.dev.js
@@ -13,7 +13,7 @@
  *  - cvv
  *
  * @website http://formvalidator.net/#security-validators
- * @version 2.2.beta.13
+ * @version 2.2.beta.14
  */
 (function($, window) {
 
@@ -347,7 +347,7 @@
                                 $(this)
                                     .valAttr('backend-valid', false)
                                     .valAttr('backend-invalid', false)
-                                    .removeAttr(conf.validationErrorMsgAttribute);
+                                ;
                             }
                         });
                 }


### PR DESCRIPTION
if server side validation does not return a specific message, don't remove the element attribute that holds a validation error message.

this allows the failure of the server side validation to use the err msg specified in the element's attr.
the specification of error messages may be in the domain / control of the web designer / form builder, and not the server side programmer.

furthermore, the data validation error message attr of the active element may need to be used by other validation routines, and if attr is removed, other validation err msgs would appear blank.
