### PR TITLE
Fix date formats without divider

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -908,7 +908,7 @@
         parseDate : function(val, dateFormat) {
             var divider = dateFormat.replace(/[a-zA-Z]/gi, '').substring(0,1),
                 regexp = '^',
-                formatParts = dateFormat.split(divider),
+                formatParts = dateFormat.split(divider || null),
                 matches, day, month, year;
 
             $.each(formatParts, function(i, part) {


### PR DESCRIPTION
Formats like `yyyy` are splitted in `formatParts = [ 'y', 'y', 'y', 'y' ]` because `divider` is an empty string.
It has to be processed with a null divider.
