### PR TITLE
Adding onInlineError callback

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -259,6 +259,11 @@
             _applyErrorStyle($elem, conf);
             _setInlineErrorMessage($elem, validation, conf, conf.errorMessagePosition);
 
+            // Run inline error callback
+            if( typeof conf.onInlineError == 'function' ) {
+                conf.onInlineError($elem, validation, conf);
+            }
+
             if(attachKeyupEvent) {
                 $elem
                     .unbind('keyup.validation')
@@ -557,7 +562,8 @@
             language : false,
             onSuccess : false,
             onError : false,
-            onElementValidate : false
+            onElementValidate : false,
+            onInlineError : false
         });
 
         conf = $.extend(defaultConf, conf || {});


### PR DESCRIPTION
I added a callback called onInlineError that is called in validateInputOnBlur function when validation fails so that DOM manipulation can occur on inline errors before the full form submit.