### PR TITLE
Escaping hyphen

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -511,7 +511,7 @@
             if( !val )
                 return [];
             var values = [];
-            $.each(val.split(func ? func: /[,|-\s]\s*/g ),
+            $.each(val.split(func ? func: /[,|\-\s]\s*/g ),
                 function(i,str) {
                     str = $.trim(str);
                     if( str.length )
@@ -521,7 +521,7 @@
             return values;
         } else if( val ) {
             // exec callback func on each
-            $.each(val.split(/[,|-\s]\s*/g),
+            $.each(val.split(/[,|\-\s]\s*/g),
                 function(i, str) {
                     str = $.trim(str);
                     if( str.length )


### PR DESCRIPTION
I ran into the  "Invalid range in the character set" issue in Firefox 31 as wizou did in IE8 ( issue https://github.com/victorjonsson/jQuery-Form-Validator/issues/215 ).  Escaping the hyphen in the regex, as recommended, seems to fix this across IE8+, Chrome, Safari, and Firefox.