### PR TITLE
Add Brazilian Validation Module

### DIFF
--- a/form-validator/brazil.dev.js
+++ b/form-validator/brazil.dev.js
@@ -1,0 +1,115 @@
+/**
+ * jQuery Form Validator Module: Brazil
+ * ------------------------------------------
+ * Created by Eduardo Cuducos <http://cuducos.me/>
+ *
+ * This form validation module adds validators typically used on
+ * websites in the Brazil. This module adds the following validators:
+ *  - cpf
+ *  - cep
+ *  - brphone
+ *
+ * @website http://formvalidator.net/#brazil-validators
+ * @license Dual licensed under the MIT or GPL Version 2 licenses
+ * @version 2.2.52
+ */
+
+$.formUtils.addValidator({
+    name : 'cpf',
+    validatorFunction : function(string) {
+
+        // Based on this post from DevMedia:
+        // http://www.devmedia.com.br/validar-cpf-com-javascript/23916
+
+        // clean up the input (digits only) and set some support vars
+        var cpf = string.replace(/\D/g,""); 
+        var sum1 = 0;
+        var sum2 = 0;
+        var remainder1 = 0;
+        var remainder2 = 0;
+
+        // skip special cases
+        if (cpf.length != 11 || cpf == "00000000000") {
+            return false;
+        }
+
+        // check 1st verification digit
+        for (i=1; i<=9; i++) {
+            sum1 += parseInt(cpf.substring(i - 1, i)) * (11 - i);
+        }
+        remainder1 = (sum * 10) % 11;
+        if (remainder1 >= 10) {
+            remainder1 = 0;
+        }
+        if (remainder != parseInt(cpf.substring(9, 10))) {
+            return false;
+        }
+
+        // check 2nd verification digit
+        for (i = 1; i <= 10; i++) {
+            sum2 += parseInt(strCPF.substring(i - 1, i)) * (12 - i);
+        }
+        remainder2 = (sum2 * 10) % 11;
+        if (remainder2 >= 10) {
+            remainder2 = 0;
+        }
+        if (remainder2 != parseInt(strCPF.substring(10, 11))) {
+            return false;
+        }
+
+        return true;
+
+    },
+    errorMessage : '',
+    errorMessageKey: 'badBrazilCPFAnswer'
+
+});
+
+$.formUtils.addValidator({
+    name : 'brphone',
+    validatorFunction : function(string) {
+
+        // validates telefones such as (having X as numbers):
+        // (XX) XXXX-XXXX
+        // (XX) XXXXX-XXXX
+        // XX XXXXXXXX
+        // XX XXXXXXXXX
+        // XXXXXXXXXX
+        // XXXXXXXXXXX
+        // +XX XX XXXXX-XXXX
+        // +X XX XXXX-XXXX
+        // And so on…
+
+        if (string.match(/^(\+[\d]{1,3}[\s]{0,1}){0,1}(\(){0,1}(\d){2}(\)){0,1}(\s){0,1}(\d){4,5}([-. ]){0,1}(\d){4}$/g)) {
+            return true;
+        }
+
+        return false;
+
+    },
+    errorMessage : '',
+    errorMessageKey: 'badBrazilTelephoneAnswer'
+
+});
+
+$.formUtils.addValidator({
+    name : 'cep',
+    validatorFunction : function(string) {
+
+        // validates CEP  such as (having X as numbers):
+        // XXXXX-XXX
+        // XXXXX.XXX
+        // XXXXX XXX
+        // XXXXXXXX
+
+        if (string.match(/^(\d){5}([-. ]){0,1}(\d){3}$/g)) {
+            return true;
+        }
+
+        return false;
+
+    },
+    errorMessage : '',
+    errorMessageKey: 'badBrazilCEPAnswer'
+
+});

--- a/form-validator/form-test.html
+++ b/form-validator/form-test.html
@@ -321,6 +321,26 @@
             <input type="reset" class="button">
         </p>
     </form>
+    <hr />
+    <form id="form-e">
+        <h2>Validation Module: Brazil</h2>
+        <div class="form-group">
+            <label class="control-label">Telephone</label>
+            <input name="brazil_telephone" data-validation="brphone" type="text" />
+        </div>
+        <div class="form-group">
+            <label class="control-label">CEP</label>
+            <input name="brazil_cep" data-validation="cep" type="text" />
+        </div>
+        <div class="form-group">
+            <label class="control-label">CPF</label>
+            <input name="brazil_cpf" data-validation="cpf" type="text" />
+        </div>
+        <p>
+            <input type="submit" class="button">
+            <input type="reset" class="button">
+        </p>
+    </form>
 </div>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
 <script src="//code.jquery.com/ui/1.10.4/jquery-ui.min.js"></script>
@@ -361,7 +381,7 @@
             lang : 'sv',
             sanitizeAll : 'trim', // only used on form C
            // borderColorOnError : 'purple',
-            modules : 'security'+dev+', location'+dev+', sweden'+dev+', file'+dev+', uk'+dev +( xtraModule ? ','+xtraModule:''),
+            modules : 'security'+dev+', location'+dev+', sweden'+dev+', file'+dev+', uk'+dev+' , brazil'+dev +( xtraModule ? ','+xtraModule:''),
             onModulesLoaded: function() {
                 $('#country-suggestions').suggestCountry();
                 $('#swedish-county-suggestions').suggestSwedishCounty();
@@ -395,6 +415,7 @@
     window.applyValidation(false, '#form-b', 'element');
     window.applyValidation(true, '#form-c', $('#error-container'), 'sanitize'+dev);
     window.applyValidation(true, '#form-d', 'element', 'html5'+dev);
+    window.applyValidation(true, '#form-e');
 
     // Load one module outside $.validate() even though you do not have to
     $.formUtils.loadModules('date'+dev+'.js', false, false);

--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -5,7 +5,7 @@
  *
  * @website http://formvalidator.net/
  * @license Dual licensed under the MIT or GPL Version 2 licenses
- * @version 2.2.51
+ * @version 2.2.52
  */
 (function ($) {
 
@@ -1415,7 +1415,10 @@
       imageTooSmall : 'the image was too small',
       min : 'min',
       max : 'max',
-      imageRatioNotAccepted : 'Image ratio is not be accepted'
+      imageRatioNotAccepted : 'Image ratio is not be accepted',
+      badBrazilTelephoneAnswer: 'The phone number entered is invalid',
+      badBrazilCEPAnswer: 'The CEP entered is invalid',
+      badBrazilCPFAnswer: 'The CPF entered is invalid'
     }
   };
 

--- a/form-validator/lang/pt.dev.js
+++ b/form-validator/lang/pt.dev.js
@@ -6,7 +6,7 @@
  *
  * @website http://formvalidator.net/
  * @license Dual licensed under the MIT or GPL Version 2 licenses
- * @version 2.2.51
+ * @version 2.2.52
  */
 (function($, window) {
 
@@ -53,7 +53,10 @@
       imageTooSmall: 'a imagem é muito pequena',
       min: 'min',
       max: 'max',
-      imageRatioNotAccepted : 'A proporção da imagem (largura x altura) não é válida'
+      imageRatioNotAccepted : 'A proporção da imagem (largura x altura) não é válida',
+      badBrazilTelephoneAnswer: 'O número de telefone digitado é inválido',
+      badBrazilCEPAnswer: 'O CEP digitado é inválido',
+      badBrazilCPFAnswer: 'O CPF digitado é inválido'
     };
 
   });


### PR DESCRIPTION
Well, the title is self-explanatory. Adds validation module to handle CPF (Brazilian Social Security #), CEP (Brazilian postal code) and Brazilian telephones (the way Brazilians use to type it). Surely more things can be added in the future, this is just a starting point…

Count on me to write the documentation and tests. I just couldn't find them in the repo.