### PR TITLE
Add universal module definition support (related to issue #329)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+#Testing, not relevant to end user
+test/
+.travis.yml
+.jshintrc
+
+#Not relevant to npm users
+bower.json
+
+#IDE
+.idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,7 @@
 //TODO: During next major version bump change to /dist. Leaving at ./form-validator for backwards
 //compatibility
 const DIST_DIR = './form-validator';
-const MAIN_PLUGIN_FILE = './form-validator/jquery.form-validator.js';
+const MAIN_PLUGIN_FILE = './form-validator/jquery.form-validator';
 const SRC_DIR = './src';
 const MAIN_DIR = '/main/';
 const MODULE_DIR = '/modules/';
@@ -79,7 +79,25 @@ function initializeGruntConfig(grunt, filesToBuild) {
       }
     },
 
-    clean: [DIST_DIR + '/']
+    clean: [DIST_DIR + '/'],
+    umd: {
+      main: {
+        options: {
+          src: MAIN_PLUGIN_FILE + '.js',
+          deps: {
+            'default': ['$']
+          }
+        }
+      },
+      minified: {
+        options: {
+          src: MAIN_PLUGIN_FILE + '.min.js',
+          deps: {
+            'default': ['$']
+          }
+        }
+      }
+    }
   });
 }
 
@@ -89,7 +107,7 @@ module.exports = function (grunt) {
       concat: {
         main:{
           src: [SRC_DIR + MAIN_DIR+'core-validators.js'],
-          dest: MAIN_PLUGIN_FILE
+          dest: MAIN_PLUGIN_FILE + '.js'
         }
       }
   };
@@ -140,8 +158,8 @@ module.exports = function (grunt) {
   };
 
   // Add main script to uglify
-  filesToBuild.uglify[MAIN_PLUGIN_FILE] = {
-    src: MAIN_PLUGIN_FILE,
+  filesToBuild.uglify[MAIN_PLUGIN_FILE + '.js'] = {
+    src: MAIN_PLUGIN_FILE + '.js',
     expand: true,
     extDot: 'last',
     ext: '.min.js'
@@ -183,7 +201,10 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-contrib-qunit');
   grunt.loadNpmTasks('grunt-contrib-cssmin');
-  grunt.registerTask("build-production", ["version", "cssmin", "test", "uglify"]);
-  grunt.registerTask('test', ['concat', 'cssmin','jshint', 'qunit']);
+  grunt.loadNpmTasks('grunt-umd');
+
+  grunt.registerTask("build-production", ["version", "test", "uglify"]);
+  grunt.registerTask('test', ['concat', 'umd', 'cssmin','jshint', 'qunit']);
   grunt.registerTask("default", ["test", "watch"]);
+  grunt.registerTask("prepublish", ["test", "uglify"]);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,7 +85,9 @@ function initializeGruntConfig(grunt, filesToBuild) {
         options: {
           src: MAIN_PLUGIN_FILE + '.js',
           deps: {
-            'default': ['$']
+            default: ['jQuery'],
+            amd: [{'jquery': 'jQuery'}],
+            cjs: [{'jquery': 'jQuery'}]
           }
         }
       },
@@ -93,7 +95,9 @@ function initializeGruntConfig(grunt, filesToBuild) {
         options: {
           src: MAIN_PLUGIN_FILE + '.min.js',
           deps: {
-            'default': ['$']
+            default: ['$'],
+            amd: [{'jquery': 'jQuery'}],
+            cjs: [{'jquery': 'jQuery'}]
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/victorjonsson/jQuery-Form-Validator.git"
   },
   "bugs": {
-    "url": "https://github.com/jquery-boilerplate/jquery-boilerplate/issues"
+    "url": "https://github.com/victorjonsson/jQuery-Form-Validator/issues"
   },
   "author": {
     "name": "Victor Jonsson",
@@ -33,6 +33,7 @@
     "grunt-contrib-qunit": "^0.7.0",
     "grunt-contrib-uglify": "~0.11.1",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-umd": "~2.3.5",
     "jquery": "^2.1.4",
     "numeral": "~1.5.3",
     "qunitjs": "^1.20.0"
@@ -41,6 +42,7 @@
     "jquery": ">1.8.0"
   },
   "scripts": {
+    "prepublish": "grunt prepublish",
     "test": "grunt test"
   }
 }


### PR DESCRIPTION
-Add prepublish script and .npmignore so prod files are always present before publishing (not necessary now since prod files are in the repo, but would be necessary if prod files are not kept in source control); this also ensures the latest version is always built/tested/minified before publishing on npm
-Add universal module definition task to add boilerplate to main files (better support for AMD and CommonJS-like environments)

This seems to work fine with Browserify (excluding add-on validation modules) and with require.js.
However, extra modules very likely won't work with Browserify out of the box. Users would have to transfer those files to the same directory the rest of the JS is in.