### PR TITLE
solve the problem when 'input-group' tag is used

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -290,6 +290,9 @@
             return $formGroup.eq(0);
           }
         }
+        if ($parent.hasClass("input-group")) {
+          return $parent.parent();
+        }
         return $parent;
       }
     },


### PR DESCRIPTION
When 'input-group' tag is used in 'form-group' with data-validation, it‘s out of shape.