### PR TITLE
Use require to load scripts if in an AMD environment

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -1014,23 +1014,27 @@
                 $.formUtils.loadedModules[scriptUrl] = 1;
                 hasLoadedAnyModule = true;
 
-                // Load the script
-                script.type = 'text/javascript';
-                script.onload = moduleLoadedCallback;
-                script.src = scriptUrl + ( scriptUrl.slice(-7) === '.dev.js' ? cacheSuffix : '' );
-                script.onerror = function() {
-                  $.formUtils.warn('Unable to load form validation module '+scriptUrl);
-                };
-                script.onreadystatechange = function () {
-                  // IE 7 fix
-                  if (this.readyState === 'complete' || this.readyState === 'loaded') {
-                    moduleLoadedCallback();
-                    // Handle memory leak in IE
-                    this.onload = null;
-                    this.onreadystatechange = null;
-                  }
-                };
-                appendToElement.appendChild(script);
+                if (typeof define === 'function' && define.amd) {
+                  require([scriptUrl + ( scriptUrl.slice(-7) === '.dev.js' ? cacheSuffix : '' )], moduleLoadedCallback);
+                } else {
+                  // Load the script
+                  script.type = 'text/javascript';
+                  script.onload = moduleLoadedCallback;
+                  script.src = scriptUrl + ( scriptUrl.slice(-7) === '.dev.js' ? cacheSuffix : '' );
+                  script.onerror = function() {
+                    $.formUtils.warn('Unable to load form validation module '+scriptUrl);
+                  };
+                  script.onreadystatechange = function () {
+                    // IE 7 fix
+                    if (this.readyState === 'complete' || this.readyState === 'loaded') {
+                      moduleLoadedCallback();
+                      // Handle memory leak in IE
+                      this.onload = null;
+                      this.onreadystatechange = null;
+                    }
+                  };
+                  appendToElement.appendChild(script);
+                }
               }
             }
           });

--- a/src/main/module-loader.js
+++ b/src/main/module-loader.js
@@ -86,23 +86,27 @@
                 $.formUtils.loadedModules[scriptUrl] = 1;
                 hasLoadedAnyModule = true;
 
-                // Load the script
-                script.type = 'text/javascript';
-                script.onload = moduleLoadedCallback;
-                script.src = scriptUrl + ( scriptUrl.slice(-7) === '.dev.js' ? cacheSuffix : '' );
-                script.onerror = function() {
-                  $.formUtils.warn('Unable to load form validation module '+scriptUrl);
-                };
-                script.onreadystatechange = function () {
-                  // IE 7 fix
-                  if (this.readyState === 'complete' || this.readyState === 'loaded') {
-                    moduleLoadedCallback();
-                    // Handle memory leak in IE
-                    this.onload = null;
-                    this.onreadystatechange = null;
-                  }
-                };
-                appendToElement.appendChild(script);
+                if (typeof define === 'function' && define.amd) {
+                  require([scriptUrl + ( scriptUrl.slice(-7) === '.dev.js' ? cacheSuffix : '' )], moduleLoadedCallback);
+                } else {
+                  // Load the script
+                  script.type = 'text/javascript';
+                  script.onload = moduleLoadedCallback;
+                  script.src = scriptUrl + ( scriptUrl.slice(-7) === '.dev.js' ? cacheSuffix : '' );
+                  script.onerror = function() {
+                    $.formUtils.warn('Unable to load form validation module '+scriptUrl);
+                  };
+                  script.onreadystatechange = function () {
+                    // IE 7 fix
+                    if (this.readyState === 'complete' || this.readyState === 'loaded') {
+                      moduleLoadedCallback();
+                      // Handle memory leak in IE
+                      this.onload = null;
+                      this.onreadystatechange = null;
+                    }
+                  };
+                  appendToElement.appendChild(script);
+                }
               }
             }
           });


### PR DESCRIPTION
Load additional scripts with require if we're in an AMD environment. This fixes https://github.com/victorjonsson/jQuery-Form-Validator/issues/546 and prevents the "mismatched anonymous define() module" error in requirejs when requiring the plugin outside of the normal requirejs environement.