### PR TITLE
Fix #444: Make 'valid' class configurable

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -296,7 +296,7 @@
     applyInputErrorStyling: function ($input, conf) {
       $input
         .addClass(conf.errorElementClass)
-        .removeClass('valid');
+        .removeClass(conf.successElementClass);
 
       this.getParentContainer($input)
         .addClass(conf.inputParentClassOnError)
@@ -315,7 +315,7 @@
 
       // Reset input css
       $input
-        .removeClass('valid')
+        .removeClass(conf.successElementClass)
         .removeClass(conf.errorElementClass)
         .css('border-color', '');
 
@@ -352,7 +352,7 @@
       }
 
       // Remove input css/messages
-      $form.find('.' + conf.errorElementClass + ',.valid').each(function() {
+      $form.find('.' + conf.errorElementClass + ',.' + conf.successElementClass).each(function() {
         dialogs.removeInputStylingAndMessage($(this), conf);
       });
     },

--- a/src/main/dialogs.js
+++ b/src/main/dialogs.js
@@ -44,7 +44,7 @@
     applyInputErrorStyling: function ($input, conf) {
       $input
         .addClass(conf.errorElementClass)
-        .removeClass('valid');
+        .removeClass(conf.successElementClass);
 
       this.getParentContainer($input)
         .addClass(conf.inputParentClassOnError)
@@ -63,7 +63,7 @@
 
       // Reset input css
       $input
-        .removeClass('valid')
+        .removeClass(conf.successElementClass)
         .removeClass(conf.errorElementClass)
         .css('border-color', '');
 
@@ -100,7 +100,7 @@
       }
 
       // Remove input css/messages
-      $form.find('.' + conf.errorElementClass + ',.valid').each(function() {
+      $form.find('.' + conf.errorElementClass + ',.' + conf.successElementClass).each(function() {
         dialogs.removeInputStylingAndMessage($(this), conf);
       });
     },

--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -18,6 +18,7 @@
       return {
         ignore: [], // Names of inputs not to be validated even though `validationRuleAttribute` containing the validation rules tells us to
         errorElementClass: 'error', // Class that will be put on elements which value is invalid
+        successElementClass: 'valid', // Class that will be put on elements that has been validated with success
         borderColorOnError: '#b94a48', // Border color of elements which value is invalid, empty string to not change border color
         errorMessageClass: 'form-error', // class name of div containing error messages when validation fails
         validationRuleAttribute: 'data-validation', // name of the attribute holding the validation rules


### PR DESCRIPTION
Add configuration option successElementClass with default to 'valid' and
replace hardcoded use of valid with that configuration.