### PR TITLE
[fix] use successElementClass instead of valid class

### DIFF
--- a/form-validator/jquery.form-validator.js
+++ b/form-validator/jquery.form-validator.js
@@ -307,7 +307,7 @@
       }
     },
     applyInputSuccessStyling: function($input, conf) {
-      $input.addClass('valid');
+      $input.addClass(conf.successElementClass);
       this.getParentContainer($input)
         .addClass(conf.inputParentClassOnSuccess);
     },

--- a/src/main/dialogs.js
+++ b/src/main/dialogs.js
@@ -55,7 +55,7 @@
       }
     },
     applyInputSuccessStyling: function($input, conf) {
-      $input.addClass('valid');
+      $input.addClass(conf.successElementClass);
       this.getParentContainer($input)
         .addClass(conf.inputParentClassOnSuccess);
     },


### PR DESCRIPTION
Fixes #579: Even-though configuration has successElementClass option, it's not applied. Instead 'valid' class is applied.