### PR TITLE
Fix issue with hyphens in file validation mime types

### DIFF
--- a/src/modules/file.js
+++ b/src/modules/file.js
@@ -25,7 +25,7 @@
       * @return {Array}
       */
       _getTypes = function($input) {
-        var allowedTypes = $.split( ($input.valAttr('allowing') || '').toLowerCase() );
+        var allowedTypes = ($input.valAttr('allowing') || '').toLowerCase().split(/,\s*/);
         if ($.inArray('jpg', allowedTypes) > -1 && $.inArray('jpeg', allowedTypes) === -1) {
           allowedTypes.push('jpeg');
         }


### PR DESCRIPTION
Addresses #646, which reported that mime types in file validations were being parsed incorrectly when they contained hyphens. This change ensures that we only split the allowed file types string at commas and trailing white space and not at hyphens.