### PR TITLE
Add empty element check in case element was filtered by toggleDisabled

### DIFF
--- a/src/main/jquery-plugins.js
+++ b/src/main/jquery-plugins.js
@@ -56,6 +56,8 @@
    * * @return {jQuery}
    */
   $.fn.validateOnEvent = function (language, config) {
+    if(this.length === 0) return;
+
     var $elements = this[0].nodeName === 'FORM' ? this.find('*[data-validation-event]') : this;
     $elements
       .each(function () {

--- a/src/main/jquery-plugins.js
+++ b/src/main/jquery-plugins.js
@@ -56,8 +56,10 @@
    * * @return {jQuery}
    */
   $.fn.validateOnEvent = function (language, config) {
-    if(this.length === 0) return;
-
+    if(this.length === 0) {
+      return;
+    }
+    
     var $elements = this[0].nodeName === 'FORM' ? this.find('*[data-validation-event]') : this;
     $elements
       .each(function () {


### PR DESCRIPTION
When using the toggleDisabled plugin, you will get an exception without the check I've added if you try filtering out a form

https://github.com/BrianRosamilia/jQuery-Form-Validator/blob/master/src/modules/toggleDisabled.js#L34-L91

On line 34, the plugin is filtering out elements and on line 91 you're calling `validateOnEvent`.  `this` will actually be an empty jQuery object if there was a form element that was filtered by `toggleDisabled`.  This causes an exception when you call `validateOnEvent` (due to the assumed existence of this[0])

I don't have a POC but hopefully this is an uncontroversial change since `this[0].` without a length === 0 check can always potentially cause an exception.  Thanks! 👍 
  
  